### PR TITLE
Add `triangles`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![pypi](https://img.shields.io/pypi/v/graphblas-algorithms.svg)](https://pypi.python.org/pypi/graphblas-algorithms/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/python-graphblas/graphblas-algorithms/blob/main/LICENSE)
 [![Tests](https://github.com/python-graphblas/graphblas-algorithms/workflows/Tests/badge.svg?branch=main)](https://github.com/python-graphblas/graphblas-algorithms/actions)
-[![Coverage](https://coveralls.io/repos/python-graphblas/graphblas-algorithms/badge.svg?branch=main)](https://coveralls.io/r/python-graphblas/graphblas-algorithms)
-[![Code style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+<!--- [![Coverage](https://coveralls.io/repos/python-graphblas/graphblas-algorithms/badge.svg?branch=main)](https://coveralls.io/r/python-graphblas/graphblas-algorithms) --->
 <!--- [![conda-forge](https://img.shields.io/conda/vn/conda-forge/graphblas-algorithms.svg)](https://anaconda.org/conda-forge/graphblas-algorithms) --->
 <!--- [![Docs](https://readthedocs.org/projects/graphblas-algorithms/badge/?version=latest)](https://graphblas-algorithms.readthedocs.io/en/latest/) --->
 

--- a/graphblas_algorithms/__init__.py
+++ b/graphblas_algorithms/__init__.py
@@ -1,5 +1,5 @@
 from . import _version
-from .cluster import clustering, transitivity, triangles  # noqa
+from .cluster import average_clustering, clustering, transitivity, triangles  # noqa
 from .link_analysis import pagerank  # noqa
 
 __version__ = _version.get_versions()["version"]

--- a/graphblas_algorithms/__init__.py
+++ b/graphblas_algorithms/__init__.py
@@ -1,5 +1,5 @@
 from . import _version
-from .cluster import transitivity, triangles  # noqa
+from .cluster import clustering, transitivity, triangles  # noqa
 from .link_analysis import pagerank  # noqa
 
 __version__ = _version.get_versions()["version"]

--- a/graphblas_algorithms/__init__.py
+++ b/graphblas_algorithms/__init__.py
@@ -1,5 +1,5 @@
 from . import _version
-from .cluster import triangles  # noqa
+from .cluster import transitivity, triangles  # noqa
 from .link_analysis import pagerank  # noqa
 
 __version__ = _version.get_versions()["version"]

--- a/graphblas_algorithms/__init__.py
+++ b/graphblas_algorithms/__init__.py
@@ -1,4 +1,5 @@
 from . import _version
+from .cluster import triangles  # noqa
 from .link_analysis import pagerank  # noqa
 
 __version__ = _version.get_versions()["version"]

--- a/graphblas_algorithms/_utils.py
+++ b/graphblas_algorithms/_utils.py
@@ -1,0 +1,46 @@
+import graphblas as gb
+from graphblas import Vector, binary
+
+
+def graph_to_adjacency(G, weight=None, dtype=None, *, name=None):
+    key_to_id = {k: i for i, k in enumerate(G)}
+    A = gb.io.from_networkx(G, nodelist=key_to_id, weight=weight, dtype=dtype, name=name)
+    return A, key_to_id
+
+
+def dict_to_vector(d, key_to_id, *, size=None, dtype=None, name=None):
+    if d is None:
+        return None
+    if size is None:
+        size = len(key_to_id)
+    indices, values = zip(*((key_to_id[key], val) for key, val in d.items()))
+    return Vector.from_values(indices, values, size=size, dtype=dtype, name=name)
+
+
+def list_to_vector(nodes, key_to_id, *, size=None, name=None):
+    if nodes is None:
+        return None, None
+    if size is None:
+        size = len(key_to_id)
+    id_to_key = {key_to_id[key]: key for key in nodes}
+    v = Vector.from_values(list(id_to_key), True, size=size, dtype=bool, name=name)
+    return v, id_to_key
+
+
+def list_to_mask(nodes, key_to_id, *, size=None, name="mask"):
+    if nodes is None:
+        return None, None
+    v, id_to_key = list_to_vector(nodes, key_to_id, size=size, name=name)
+    return v.S, id_to_key
+
+
+def vector_to_dict(v, key_to_id, id_to_key=None, *, mask=None, fillvalue=None):
+    # This mutates the vector to fill it!
+    if id_to_key is None:
+        id_to_key = {key_to_id[key]: key for key in key_to_id}
+    if mask is not None:
+        if fillvalue is not None and v.nvals < mask.parent.nvals:
+            v(mask, binary.first) << fillvalue
+    elif fillvalue is not None and v.nvals < v.size:
+        v(mask=~v.S) << fillvalue
+    return {id_to_key[index]: value for index, value in zip(*v.to_values(sort=False))}

--- a/graphblas_algorithms/cluster.py
+++ b/graphblas_algorithms/cluster.py
@@ -1,0 +1,60 @@
+from collections import OrderedDict
+
+import graphblas as gb
+from graphblas import Matrix, Vector, binary, select
+from graphblas.semiring import any_pair, plus_pair
+from networkx.utils import not_implemented_for
+
+
+def single_triangle_core(G, index):
+    M = Matrix(bool, G.nrows, G.ncols)
+    M[index, index] = False
+    C = any_pair(G.T @ M.T).new(name="C")  # select.coleq(G, index)
+    del C[index, index]  # Ignore self-edges
+    R = C.T.new(name="R")
+    return plus_pair(G @ R.T).new(mask=C.S).reduce_scalar(allow_empty=False).value // 2
+
+
+def triangles_core(G, mask=None):
+    # Ignores self-edges
+    L = select.tril(G, -1).new(name="L")
+    U = select.triu(G, 1).new(name="U")
+    C = plus_pair(L @ L.T).new(mask=L.S)
+    return (
+        C.reduce_rowwise().new(mask=mask)
+        + C.reduce_columnwise().new(mask=mask)
+        + plus_pair(U @ L.T).new(mask=U.S).reduce_rowwise().new(mask=mask)
+    ).new(name="triangles")
+
+
+def total_triangles_core(G):
+    # Ignores self-edges
+    L = select.tril(G, -1).new(name="L")
+    U = select.triu(G, 1).new(name="U")
+    return plus_pair(L @ U.T).new(mask=L.S).reduce_scalar(allow_empty=False).value
+
+
+@not_implemented_for("directed")
+def triangles(G, nodes=None):
+    N = len(G)
+    if N == 0:
+        return {}
+    node_ids = OrderedDict((k, i) for i, k in enumerate(G))
+    A = gb.io.from_networkx(G, nodelist=node_ids, weight=None, dtype=bool)
+    if nodes in G:
+        return single_triangle_core(A, node_ids[nodes])
+    if nodes is not None:
+        id_to_key = {node_ids[key]: key for key in nodes}
+        mask = Vector.from_values(list(id_to_key), True, size=N, dtype=bool, name="mask").S
+    else:
+        mask = None
+    result = triangles_core(A, mask=mask)
+    if nodes is not None:
+        if result.nvals != len(id_to_key):
+            result(mask, binary.first) << 0
+        indices, values = result.to_values()
+        return {id_to_key[index]: value for index, value in zip(indices, values)}
+    elif result.nvals != N:
+        # Fill with zero
+        result(mask=~result.S) << 0
+    return dict(zip(node_ids, result.to_values()[1]))

--- a/graphblas_algorithms/cluster.py
+++ b/graphblas_algorithms/cluster.py
@@ -6,6 +6,38 @@ from graphblas.semiring import any_pair, plus_pair
 from networkx.utils import not_implemented_for
 
 
+def get_properties(G, names, *, L=None, U=None, degrees=None, has_self_edges=True):
+    if isinstance(names, str):
+        # Separated by commas and/or spaces
+        names = [name for name in names.replace(" ", ",").split(",") if name]
+    rv = []
+    for name in names:
+        if name == "L":
+            if L is None:
+                L = select.tril(G, -1).new(name="L")
+            rv.append(L)
+        elif name == "U":
+            if U is None:
+                U = select.triu(G, 1).new(name="U")
+            rv.append(U)
+        elif name == "degrees":
+            if degrees is None:
+                if has_self_edges:
+                    if L is None or U is None:
+                        L, U, degrees = get_properties(G, "L U degrees", L=L, U=U, degrees=degrees)
+                    degrees = (L.reduce_rowwise(agg.count) + U.reduce_rowwise(agg.count)).new(
+                        name="degrees"
+                    )
+                else:
+                    degrees = G.reduce_rowwise(agg.count).new(name="degrees")
+            rv.append(degrees)
+        else:
+            raise ValueError(f"Unknown property name: {name}")
+    if len(rv) == 1:
+        return rv[0]
+    return rv
+
+
 def single_triangle_core(G, index, *, L=None, has_self_edges=True):
     M = Matrix(bool, G.nrows, G.ncols)
     M[index, index] = False
@@ -14,10 +46,9 @@ def single_triangle_core(G, index, *, L=None, has_self_edges=True):
         del C[index, index]  # Ignore self-edges
     R = C.T.new(name="R")
     if has_self_edges:
-        if L is None:
-            # Pretty much all the time is spent here.
-            # We take the TRIL as a way to ignore the self-edges.
-            L = select.tril(G, -1).new(name="L")
+        # Pretty much all the time is spent here taking TRIL.
+        # We take the TRIL as a way to ignore the self-edges.
+        L = get_properties(G, "L", L=L)
         return plus_pair(L @ R.T).new(mask=C.S).reduce_scalar(allow_empty=False).value
     else:
         return plus_pair(G @ R.T).new(mask=C.S).reduce_scalar(allow_empty=False).value // 2
@@ -25,10 +56,7 @@ def single_triangle_core(G, index, *, L=None, has_self_edges=True):
 
 def triangles_core(G, mask=None, *, L=None, U=None):
     # Ignores self-edges
-    if L is None:
-        L = select.tril(G, -1).new(name="L")
-    if U is None:
-        U = select.triu(G, 1).new(name="U")
+    L, U = get_properties(G, "L U", L=L, U=U)
     C = plus_pair(L @ L.T).new(mask=L.S)
     return (
         C.reduce_rowwise().new(mask=mask)
@@ -41,10 +69,7 @@ def total_triangles_core(G, *, L=None, U=None):
     # Ignores self-edges
     # We use SandiaDot method, because it's usually the fastest on large graphs.
     # For smaller graphs, Sandia method is usually faster: plus_pair(L @ L).new(mask=L.S)
-    if L is None:
-        L = select.tril(G, -1).new(name="L")
-    if U is None:
-        U = select.triu(G, 1).new(name="U")
+    L, U = get_properties(G, "L U", L=L, U=U)
     return plus_pair(L @ U.T).new(mask=L.S).reduce_scalar(allow_empty=False).value
 
 
@@ -74,25 +99,33 @@ def triangles(G, nodes=None):
     return dict(zip(node_ids, result.to_values()[1]))
 
 
-def transitivity_core(G, *, L=None, U=None, has_self_edges=True):
-    if L is None:
-        L = select.tril(G, -1).new(name="L")
-    if U is None:
-        U = select.triu(G, 1).new(name="U")
+def transitivity_core(G, *, L=None, U=None, degrees=None, has_self_edges=True):
+    L, U = get_properties(G, "L U", L=L, U=U)
     numerator = total_triangles_core(G, L=L, U=U)
     if numerator == 0:
         return 0
-    if has_self_edges:
-        degrees = L.reduce_rowwise(agg.count) + U.reduce_rowwise(agg.count)
-    else:
-        degrees = G.reduce_rowwise(agg.count)
+    degrees = get_properties(G, "degrees", L=L, U=U, degrees=degrees, has_self_edges=has_self_edges)
     denom = (degrees * (degrees - 1)).reduce().value
     return 6 * numerator / denom
 
 
-@not_implemented_for("directed")
+@not_implemented_for("directed")  # Should we implement it for directed?
 def transitivity(G):
     if len(G) == 0:
         return 0
     A = gb.io.from_networkx(G, weight=None, dtype=bool)
     return transitivity_core(A)
+
+
+def clustering_core(G, *, L=None, U=None, degrees=None, has_self_edges=True):
+    L, U, degrees = get_properties(
+        G, "L U degrees", L=L, U=U, degrees=degrees, has_self_edges=has_self_edges
+    )
+    tri = triangles_core(G, L=L, U=U)
+    denom = degrees * (degrees - 1)
+    return (2 * tri / denom).new(name="clustering")
+
+
+@not_implemented_for("directed")  # TODO: implement for directed
+def clustering(G, nodes=None, weight=None):
+    pass

--- a/graphblas_algorithms/cluster.py
+++ b/graphblas_algorithms/cluster.py
@@ -10,7 +10,8 @@ def single_triangle_core(G, index, *, L=None, has_self_edges=True):
     M = Matrix(bool, G.nrows, G.ncols)
     M[index, index] = False
     C = any_pair(G.T @ M.T).new(name="C")  # select.coleq(G.T, index)
-    del C[index, index]  # Ignore self-edges
+    if has_self_edges:
+        del C[index, index]  # Ignore self-edges
     R = C.T.new(name="R")
     if has_self_edges:
         if L is None:

--- a/graphblas_algorithms/tests/test_cluster.py
+++ b/graphblas_algorithms/tests/test_cluster.py
@@ -56,7 +56,7 @@ def test_triangles_full():
     assert ga.cluster.total_triangles_core(G) == 10
     assert ga.cluster.total_triangles_core(G, L=L, U=U) == 10
     assert ga.cluster.transitivity_core(G) == 1.0
-    assert ga.cluster.transitivity_core(G2, has_self_edges=False) == 1.0
+    assert ga.cluster.transitivity_core(G2) == 1.0
 
 
 from networkx.algorithms.tests.test_cluster import *  # noqa isort:skip

--- a/graphblas_algorithms/tests/test_cluster.py
+++ b/graphblas_algorithms/tests/test_cluster.py
@@ -4,17 +4,25 @@ import graphblas as gb
 import networkx as nx
 
 import graphblas_algorithms as ga
-from graphblas_algorithms import triangles
+from graphblas_algorithms import transitivity, triangles
 
 nx_triangles = nx.triangles
 nx.triangles = triangles
 nx.algorithms.triangles = triangles
 nx.algorithms.cluster.triangles = triangles
 
+nx_transitivity = nx.transitivity
+nx.transitivity = transitivity
+nx.algorithms.transitivity = transitivity
+nx.algorithms.cluster.transitivity = transitivity
+
 
 def test_signatures():
     nx_sig = inspect.signature(nx_triangles)
     sig = inspect.signature(triangles)
+    assert nx_sig == sig
+    nx_sig = inspect.signature(nx_transitivity)
+    sig = inspect.signature(transitivity)
     assert nx_sig == sig
 
 
@@ -47,6 +55,8 @@ def test_triangles_full():
     assert ga.cluster.total_triangles_core(G2) == 10
     assert ga.cluster.total_triangles_core(G) == 10
     assert ga.cluster.total_triangles_core(G, L=L, U=U) == 10
+    assert ga.cluster.transitivity_core(G) == 1.0
+    assert ga.cluster.transitivity_core(G2, has_self_edges=False) == 1.0
 
 
 from networkx.algorithms.tests.test_cluster import *  # noqa isort:skip

--- a/graphblas_algorithms/tests/test_cluster.py
+++ b/graphblas_algorithms/tests/test_cluster.py
@@ -22,11 +22,14 @@ def test_triangles_full():
     # Including self-edges!
     G = gb.Matrix(bool, 5, 5)
     G[:, :] = True
+    G2 = gb.select.offdiag(G).new()
     L = gb.select.tril(G, -1).new(name="L")
     U = gb.select.triu(G, 1).new(name="U")
     result = ga.cluster.triangles_core(G, L=L, U=U)
     expected = gb.Vector(int, 5)
     expected[:] = 6
+    assert result.isequal(expected)
+    result = ga.cluster.triangles_core(G2, L=L, U=U)
     assert result.isequal(expected)
     mask = gb.Vector(bool, 5)
     mask[0] = True
@@ -36,7 +39,12 @@ def test_triangles_full():
     expected[0] = 6
     expected[3] = 6
     assert result.isequal(expected)
+    result = ga.cluster.triangles_core(G2, mask=mask.S)
+    assert result.isequal(expected)
+    assert ga.cluster.single_triangle_core(G, 1) == 6
     assert ga.cluster.single_triangle_core(G, 0, L=L) == 6
+    assert ga.cluster.single_triangle_core(G2, 0, has_self_edges=False) == 6
+    assert ga.cluster.total_triangles_core(G2) == 10
     assert ga.cluster.total_triangles_core(G) == 10
     assert ga.cluster.total_triangles_core(G, L=L, U=U) == 10
 

--- a/graphblas_algorithms/tests/test_cluster.py
+++ b/graphblas_algorithms/tests/test_cluster.py
@@ -4,7 +4,7 @@ import graphblas as gb
 import networkx as nx
 
 import graphblas_algorithms as ga
-from graphblas_algorithms import transitivity, triangles
+from graphblas_algorithms import clustering, transitivity, triangles
 
 nx_triangles = nx.triangles
 nx.triangles = triangles
@@ -16,6 +16,11 @@ nx.transitivity = transitivity
 nx.algorithms.transitivity = transitivity
 nx.algorithms.cluster.transitivity = transitivity
 
+nx_clustering = nx.clustering
+nx.clustering = clustering
+nx.algorithms.clustering = clustering
+nx.algorithms.cluster.clustering = clustering
+
 
 def test_signatures():
     nx_sig = inspect.signature(nx_triangles)
@@ -23,6 +28,9 @@ def test_signatures():
     assert nx_sig == sig
     nx_sig = inspect.signature(nx_transitivity)
     sig = inspect.signature(transitivity)
+    assert nx_sig == sig
+    nx_sig = inspect.signature(nx_clustering)
+    sig = inspect.signature(clustering)
     assert nx_sig == sig
 
 
@@ -57,6 +65,19 @@ def test_triangles_full():
     assert ga.cluster.total_triangles_core(G, L=L, U=U) == 10
     assert ga.cluster.transitivity_core(G) == 1.0
     assert ga.cluster.transitivity_core(G2) == 1.0
+    result = ga.cluster.clustering_core(G)
+    expected = gb.Vector(float, 5)
+    expected[:] = 1
+    assert result.isequal(expected)
+    result = ga.cluster.clustering_core(G2)
+    assert result.isequal(expected)
+    assert ga.cluster.single_clustering_core(G, 0) == 1
+    assert ga.cluster.single_clustering_core(G2, 0) == 1
+    expected(mask.S, replace=True) << 1
+    result = ga.cluster.clustering_core(G, mask=mask.S)
+    assert result.isequal(expected)
+    result = ga.cluster.clustering_core(G2, mask=mask.S)
+    assert result.isequal(expected)
 
 
 from networkx.algorithms.tests.test_cluster import *  # noqa isort:skip

--- a/graphblas_algorithms/tests/test_cluster.py
+++ b/graphblas_algorithms/tests/test_cluster.py
@@ -1,0 +1,19 @@
+import inspect
+
+import networkx as nx
+
+from graphblas_algorithms import triangles
+
+nx_triangles = nx.triangles
+nx.triangles = triangles
+nx.algorithms.triangles = triangles
+nx.algorithms.cluster.triangles = triangles
+
+
+def test_signatures():
+    nx_sig = inspect.signature(nx_triangles)
+    sig = inspect.signature(triangles)
+    assert nx_sig == sig
+
+
+from networkx.algorithms.tests.test_cluster import *  # noqa isort:skip

--- a/graphblas_algorithms/tests/test_cluster.py
+++ b/graphblas_algorithms/tests/test_cluster.py
@@ -1,7 +1,9 @@
 import inspect
 
+import graphblas as gb
 import networkx as nx
 
+import graphblas_algorithms as ga
 from graphblas_algorithms import triangles
 
 nx_triangles = nx.triangles
@@ -14,6 +16,29 @@ def test_signatures():
     nx_sig = inspect.signature(nx_triangles)
     sig = inspect.signature(triangles)
     assert nx_sig == sig
+
+
+def test_triangles_full():
+    # Including self-edges!
+    G = gb.Matrix(bool, 5, 5)
+    G[:, :] = True
+    L = gb.select.tril(G, -1).new(name="L")
+    U = gb.select.triu(G, 1).new(name="U")
+    result = ga.cluster.triangles_core(G, L=L, U=U)
+    expected = gb.Vector(int, 5)
+    expected[:] = 6
+    assert result.isequal(expected)
+    mask = gb.Vector(bool, 5)
+    mask[0] = True
+    mask[3] = True
+    result = ga.cluster.triangles_core(G, mask=mask.S)
+    expected = gb.Vector(int, 5)
+    expected[0] = 6
+    expected[3] = 6
+    assert result.isequal(expected)
+    assert ga.cluster.single_triangle_core(G, 0, L=L) == 6
+    assert ga.cluster.total_triangles_core(G) == 10
+    assert ga.cluster.total_triangles_core(G, L=L, U=U) == 10
 
 
 from networkx.algorithms.tests.test_cluster import *  # noqa isort:skip

--- a/graphblas_algorithms/tests/test_cluster.py
+++ b/graphblas_algorithms/tests/test_cluster.py
@@ -4,7 +4,7 @@ import graphblas as gb
 import networkx as nx
 
 import graphblas_algorithms as ga
-from graphblas_algorithms import clustering, transitivity, triangles
+from graphblas_algorithms import average_clustering, clustering, transitivity, triangles
 
 nx_triangles = nx.triangles
 nx.triangles = triangles
@@ -20,6 +20,11 @@ nx_clustering = nx.clustering
 nx.clustering = clustering
 nx.algorithms.clustering = clustering
 nx.algorithms.cluster.clustering = clustering
+
+nx_average_clustering = nx.average_clustering
+nx.average_clustering = average_clustering
+nx.algorithms.average_clustering = average_clustering
+nx.algorithms.cluster.average_clustering = average_clustering
 
 
 def test_signatures():
@@ -78,6 +83,10 @@ def test_triangles_full():
     assert result.isequal(expected)
     result = ga.cluster.clustering_core(G2, mask=mask.S)
     assert result.isequal(expected)
+    assert ga.cluster.average_clustering_core(G) == 1
+    assert ga.cluster.average_clustering_core(G2) == 1
+    assert ga.cluster.average_clustering_core(G, mask=mask.S) == 1
+    assert ga.cluster.average_clustering_core(G2, mask=mask.S) == 1
 
 
 from networkx.algorithms.tests.test_cluster import *  # noqa isort:skip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-python-graphblas >=2022.4.1
+python-graphblas >=2022.4.2
+networkx

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ extras_require = {
 }
 extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
 
+with open("requirements.txt") as f:
+    install_requires = f.read().strip().split("\n")
 with open("README.md") as f:
     long_description = f.read()
 
@@ -22,7 +24,7 @@ setup(
     url="https://github.com/python-graphblas/graphblas-algorithms",
     packages=find_packages(),
     python_requires=">=3.8",
-    install_requires=["python-graphblas >=2022.4.1", "networkx"],
+    install_requires=install_requires,
     extras_require=extras_require,
     include_package_data=True,
     license="Apache License 2.0",


### PR DESCRIPTION
I think the tests could be improved.  Some of the NetworkX tests get coverage,
but only compare to 0 triangles.  Also, we should test more with self-edges.

There may be better ways to compute triangles for:
- all nodes
- a subset of nodes
- a single node

There are *a lot* of different ways to compute triangles, so this could be
explored further in the future.  I hope the current PR is competitive.