### PR TITLE
Support directed graphs in clustering / triangle counting

### DIFF
--- a/graphblas_algorithms/cluster.py
+++ b/graphblas_algorithms/cluster.py
@@ -1,6 +1,6 @@
 import graphblas as gb
 import networkx as nx
-from graphblas import agg, binary, select
+from graphblas import binary, select
 from graphblas.semiring import plus_pair
 from networkx import average_clustering as _nx_average_clustering
 from networkx import clustering as _nx_clustering
@@ -51,10 +51,11 @@ def get_degrees(G, mask=None, *, L=None, U=None, has_self_edges=True):
         if L is None or U is None:
             L, U = get_properties(G, "L U", L=L, U=U)
         degrees = (
-            L.reduce_rowwise(agg.count).new(mask=mask) + U.reduce_rowwise(agg.count).new(mask=mask)
+            L.reduce_rowwise(gb.agg.count).new(mask=mask)
+            + U.reduce_rowwise(gb.agg.count).new(mask=mask)
         ).new(name="degrees")
     else:
-        degrees = G.reduce_rowwise(agg.count).new(mask=mask, name="degrees")
+        degrees = G.reduce_rowwise(gb.agg.count).new(mask=mask, name="degrees")
     return degrees
 
 
@@ -119,7 +120,7 @@ def transitivity_directed_core(G, *, has_self_edges=True):
     numerator = plus_pair(A @ A.T).new(mask=A.S).reduce_scalar(allow_empty=False).value
     if numerator == 0:
         return 0
-    deg = A.reduce_rowwise(agg.count)
+    deg = A.reduce_rowwise(gb.agg.count)
     denom = (deg * (deg - 1)).reduce().value
     return numerator / denom
 
@@ -160,7 +161,7 @@ def clustering_directed_core(G, mask=None, *, has_self_edges=True):
     )
     recip_degrees = binary.pair(A & AT).reduce_rowwise().new(mask=mask)
     total_degrees = (
-        A.reduce_rowwise(agg.count).new(mask=mask) + A.reduce_columnwise(agg.count)
+        A.reduce_rowwise(gb.agg.count).new(mask=mask) + A.reduce_columnwise(gb.agg.count)
     ).new(mask=mask)
     return (tri / (total_degrees * (total_degrees - 1) - 2 * recip_degrees)).new(name="clustering")
 

--- a/graphblas_algorithms/tests/test_cluster.py
+++ b/graphblas_algorithms/tests/test_cluster.py
@@ -89,13 +89,34 @@ def test_triangles_full():
     assert ga.cluster.average_clustering_core(G2, mask=mask.S) == 1
 
 
-def test_transitivity_directed():
+def test_directed():
     # XXX" is transitivity supposed to work on directed graphs like this?
     G = nx.complete_graph(5, create_using=nx.DiGraph())
     G.remove_edge(1, 2)
+    G.remove_edge(2, 3)
+    G.add_node(5)
     expected = nx_transitivity(G)
     result = transitivity(G)
     assert expected == result
+    # clustering
+    expected = nx_clustering(G)
+    result = clustering(G)
+    assert result == expected
+    expected = nx_clustering(G, [0, 1, 2])
+    result = clustering(G, [0, 1, 2])
+    assert result == expected
+    for i in range(6):
+        assert nx_clustering(G, i) == clustering(G, i)
+    # average_clustering
+    expected = nx_average_clustering(G)
+    result = average_clustering(G)
+    assert result == expected
+    expected = nx_average_clustering(G, [0, 1, 2])
+    result = average_clustering(G, [0, 1, 2])
+    assert result == expected
+    expected = nx_average_clustering(G, count_zeros=False)
+    result = average_clustering(G, count_zeros=False)
+    assert result == expected
 
 
 from networkx.algorithms.tests.test_cluster import *  # noqa isort:skip

--- a/graphblas_algorithms/tests/test_cluster.py
+++ b/graphblas_algorithms/tests/test_cluster.py
@@ -89,4 +89,13 @@ def test_triangles_full():
     assert ga.cluster.average_clustering_core(G2, mask=mask.S) == 1
 
 
+def test_transitivity_directed():
+    # XXX" is transitivity supposed to work on directed graphs like this?
+    G = nx.complete_graph(5, create_using=nx.DiGraph())
+    G.remove_edge(1, 2)
+    expected = nx_transitivity(G)
+    result = transitivity(G)
+    assert expected == result
+
+
 from networkx.algorithms.tests.test_cluster import *  # noqa isort:skip


### PR DESCRIPTION
Computing the clustering coefficient for directed graphs (via `clustering_directed_core`) is actually pretty interesting!  It doesn't just count the cycles, it actually considers _all eight_ possible orientations of each triangle edge.  I came up with the implementation through trial and error.

@MridulS, any idea if transitivity is supposed to work on directed graphs?  I can also ask this when I make a PR adding tests to networkx.

Anyway, I still need to do a better job computing properties for directed graphs.  I'll probably do this when I refactor to make `Graph` classes in `graphblas-algorithms`.  Also, self-edges are annoying, and I wonder when we'll need cached properties that include self-edges (the functions in cluster.py are supposed to ignore self-edges I believe).