### PR TITLE
Enhance caching to allow things like `plus_rowwise-` and `min_element+`

### DIFF
--- a/graphblas_algorithms/algorithms/link_analysis/pagerank_alg.py
+++ b/graphblas_algorithms/algorithms/link_analysis/pagerank_alg.py
@@ -45,10 +45,8 @@ def pagerank_core(
     # Inverse of row_degrees
     # Fold alpha constant into S
     if row_degrees is None:
-        S = A.reduce_rowwise().new(float, name="S")  # XXX: What about self-edges
-        S << alpha / S
-    else:
-        S = (alpha / row_degrees).new(name="S")
+        row_degrees = G.get_property("plus_rowwise+")  # XXX: What about self-edges?
+    S = (alpha / row_degrees).new(name="S")
 
     if A.ss.is_iso:
         # Fold iso-value of A into S
@@ -124,8 +122,7 @@ def pagerank(
     # We'll normalize initial, personalization, and dangling vectors later
     x = G.dict_to_vector(nstart, dtype=float, name="nstart")
     p = G.dict_to_vector(personalization, dtype=float, name="personalization")
-    row_degrees = G._A.reduce_rowwise().new(name="row_degrees")  # XXX: What about self-edges?
-    # row_degrees = G.get_property('plus_rowwise+')  # Maybe?
+    row_degrees = G.get_property("plus_rowwise+")  # XXX: What about self-edges?
     if dangling is not None and row_degrees.nvals < N:
         dangling_weights = G.dict_to_vector(dangling, dtype=float, name="dangling")
     else:

--- a/graphblas_algorithms/classes/_caching.py
+++ b/graphblas_algorithms/classes/_caching.py
@@ -1,0 +1,176 @@
+from graphblas import agg, op, operator
+
+
+def get_reduce_to_vector(key, opname, methodname):
+    try:
+        op_ = op.from_string(opname)
+    except ValueError:
+        op_ = agg.from_string(opname)
+    op_, opclass = operator.find_opclass(op_)
+    keybase = key[:-1]
+    if key[-1] == "-":
+
+        def get_reduction(G, mask=None):
+            cache = G._cache
+            if mask is not None:
+                if key in cache:
+                    return cache[key].dup(mask=mask)
+                elif cache.get("has_self_edges") is False and f"{keybase}+" in cache:
+                    cache[key] = cache[f"{keybase}+"]
+                    return cache[key].dup(mask=mask)
+                elif "offdiag" in cache:
+                    return getattr(cache["offdiag"], methodname)(op_).new(mask=mask, name=key)
+                elif (
+                    "L-" in cache
+                    and "U-" in cache
+                    and opclass in {"BinaryOp", "Monoid"}
+                    and G.get_property("has_self_edges")
+                ):
+                    return op_(
+                        getattr(cache["L-"], methodname)(op_).new(mask=mask)
+                        | getattr(cache["U-"], methodname)(op_).new(mask=mask)
+                    ).new(name=key)
+                elif not G.get_property("has_self_edges"):
+                    return G.get_property(f"{keybase}+", mask=mask)
+                else:
+                    return getattr(G.get_property("offdiag"), methodname)(op_).new(
+                        mask=mask, name=key
+                    )
+            if key not in cache:
+                if cache.get("has_self_edges") is False and f"{keybase}+" in cache:
+                    cache[key] = cache[f"{keybase}+"]
+                elif "offdiag" in cache:
+                    cache[key] = getattr(cache["offdiag"], methodname)(op_).new(name=key)
+                elif (
+                    "L-" in cache
+                    and "U-" in cache
+                    and opclass in {"BinaryOp", "Monoid"}
+                    and G.get_property("has_self_edges")
+                ):
+                    cache[key] = op_(
+                        getattr(cache["L-"], methodname)(op_)
+                        | getattr(cache["U-"], methodname)(op_)
+                    ).new(name=key)
+                elif not G.get_property("has_self_edges"):
+                    cache[key] = G.get_property(f"{keybase}+")
+                else:
+                    cache[key] = getattr(G.get_property("offdiag"), methodname)(op_).new(name=key)
+            if (
+                "has_self_edges" not in cache
+                and f"{keybase}+" in cache
+                and cache[key].nvals != cache[f"{keybase}+"].nvals
+            ):
+                cache["has_self_edges"] = True
+            elif cache.get("has_self_edges") is False:
+                cache[f"{keybase}+"] = cache[key]
+            return cache[key]
+
+    else:
+
+        def get_reduction(G, mask=None):
+            A = G._A
+            cache = G._cache
+            if mask is not None:
+                if key in cache:
+                    return cache[key].dup(mask=mask)
+                elif cache.get("has_self_edges") is False and f"{keybase}-" in cache:
+                    cache[key] = cache[f"{keybase}-"]
+                    return cache[key].dup(mask=mask)
+                elif methodname == "reduce_columnwise" and "AT" in cache:
+                    return cache["AT"].reduce_rowwise(op_).new(mask=mask, name=key)
+                else:
+                    return getattr(A, methodname)(op_).new(mask=mask, name=key)
+            if key not in cache:
+                if cache.get("has_self_edges") is False and f"{keybase}-" in cache:
+                    cache[key] = cache[f"{keybase}-"]
+                elif methodname == "reduce_columnwise" and "AT" in cache:
+                    cache[key] = cache["AT"].reduce_rowwise(op_).new(name=key)
+                else:
+                    cache[key] = getattr(A, methodname)(op_).new(name=key)
+            if (
+                "has_self_edges" not in cache
+                and f"{keybase}-" in cache
+                and cache[key].nvals != cache[f"{keybase}-"].nvals
+            ):
+                cache["has_self_edges"] = True
+            elif cache.get("has_self_edges") is False:
+                cache[f"{keybase}-"] = cache[key]
+            return cache[key]
+
+    return get_reduction
+
+
+def get_reduce_to_scalar(key, opname):
+    try:
+        op_ = op.from_string(opname)
+    except ValueError:
+        op_ = agg.from_string(opname)
+    op_, opclass = operator.find_opclass(op_)
+    keybase = key[:-1]
+    if key[-1] == "-":
+
+        def get_reduction(G, mask=None):
+            cache = G._cache
+            if key not in cache:
+                if cache.get("has_self_edges") is False and f"{keybase}+" in cache:
+                    cache[key] = cache[f"{keybase}+"]
+                elif f"{opname}_rowwise-" in cache:
+                    cache[key] = cache[f"{opname}_rowwise-"].reduce(op_).new(name=key)
+                elif f"{opname}_columnwise-" in cache:
+                    cache[key] = cache[f"{opname}_columnwise-"].reduce(op_).new(name=key)
+                elif cache.get("has_self_edges") is False and f"{opname}_rowwise+" in cache:
+                    cache[key] = cache[f"{opname}_rowwise+"].reduce(op_).new(name=key)
+                elif cache.get("has_self_edges") is False and f"{opname}_columnwise+" in cache:
+                    cache[key] = cache[f"{opname}_columnwise+"].reduce(op_).new(name=key)
+                elif "offdiag" in cache:
+                    cache[key] = cache["offdiag"].reduce_scalar(op_).new(name=key)
+                elif (
+                    "L-" in cache
+                    and "U-" in cache
+                    and opclass in {"BinaryOp", "Monoid"}
+                    and G.get_property("has_self_edges")
+                ):
+                    return op_(
+                        cache["L-"].reduce(op_)._as_vector() | cache["U-"].reduce(op_)._as_vector()
+                    )[0].new(name=key)
+                elif not G.get_property("has_self_edges"):
+                    cache[key] = cache[f"{keybase}+"]
+                else:
+                    cache[key] = G.get_property("offdiag").reduce_scalar(op_).new(name=key)
+            if (
+                "has_self_edges" not in cache
+                and f"{keybase}+" in cache
+                and cache[key] != cache[f"{keybase}+"]
+            ):
+                cache["has_self_edges"] = True
+            elif cache.get("has_self_edges") is False:
+                cache[f"{keybase}+"] = cache[key]
+            return cache[key]
+
+    else:
+
+        def get_reduction(G, mask=None):
+            A = G._A
+            cache = G._cache
+            if key not in cache:
+                if cache.get("has_self_edges") is False and f"{keybase}-" in cache:
+                    cache[key] = cache[f"{keybase}-"]
+                elif f"{opname}_rowwise+" in cache:
+                    cache[key] = cache[f"{opname}_rowwise+"].reduce(op_).new(name=key)
+                elif f"{opname}_columnwise+" in cache:
+                    cache[key] = cache[f"{opname}_columnwise+"].reduce(op_).new(name=key)
+                elif cache.get("has_self_edges") is False and f"{opname}_rowwise-" in cache:
+                    cache[key] = cache[f"{opname}_rowwise-"].reduce(op_).new(name=key)
+                elif cache.get("has_self_edges") is False and f"{opname}_columnwise-" in cache:
+                    cache[key] = cache[f"{opname}_columnwise-"].reduce(op_).new(name=key)
+                else:
+                    cache[key] = A.reduce_scalar(op_).new(name=key)
+            if (
+                "has_self_edges" not in cache
+                and f"{keybase}-" in cache
+                and cache[key] != cache[f"{keybase}-"]
+            ):
+                cache["has_self_edges"] = True
+            elif cache.get("has_self_edges") is False:
+                cache[f"{keybase}-"] = cache[key]
+            return cache[key]

--- a/graphblas_algorithms/classes/_caching.py
+++ b/graphblas_algorithms/classes/_caching.py
@@ -134,7 +134,7 @@ def get_reduce_to_scalar(key, opname):
                         cache["L-"].reduce(op_)._as_vector() | cache["U-"].reduce(op_)._as_vector()
                     )[0].new(name=key)
                 elif not G.get_property("has_self_edges"):
-                    cache[key] = cache[f"{keybase}+"]
+                    cache[key] = G.get_property(f"{keybase}+")
                 else:
                     cache[key] = G.get_property("offdiag").reduce_scalar(op_).new(name=key)
             if (
@@ -174,3 +174,5 @@ def get_reduce_to_scalar(key, opname):
             elif cache.get("has_self_edges") is False:
                 cache[f"{keybase}-"] = cache[key]
             return cache[key]
+
+    return get_reduction


### PR DESCRIPTION
I'm not sure I like everything here, but let's try going with it for now.  This performs e.g. `"plus_rowwise+"` by matching the `"rowwise+"` substring and gets `"plus"` as the operator name.

Doing `"plus_rowwise-"` is actually pretty convenient, and it lets us bundle a bunch of logic into a couple functions.  Also, caching algorithm results seems useful; for now, we only cache scalar results.

Getting coverage on all this caching logic is going to be a pain, but I think it'll be doable.

I'm also totally open to a complete rework or refactor of caching.