### PR TITLE
Support weighted clustering

### DIFF
--- a/graphblas_algorithms/algorithms/cluster.py
+++ b/graphblas_algorithms/algorithms/cluster.py
@@ -1,31 +1,50 @@
-from graphblas import binary
-from graphblas.semiring import plus_pair
-from networkx import average_clustering as _nx_average_clustering
-from networkx import clustering as _nx_clustering
+from graphblas import binary, unary
+from graphblas.semiring import plus_pair, plus_times
 
 from graphblas_algorithms.classes.digraph import to_graph
 from graphblas_algorithms.classes.graph import to_undirected_graph
 from graphblas_algorithms.utils import not_implemented_for
 
 
-def single_triangle_core(G, node):
+def single_triangle_core(G, node, *, weighted=False):
     index = G._key_to_id[node]
     r = G._A[index, :].new()
     # Pretty much all the time is spent here taking TRIL, which is used to ignore self-edges
     L = G.get_property("L-")
     if G.get_property("has_self_edges"):
         del r[index]  # Ignore self-edges
-    return plus_pair(L @ r).new(mask=r.S).reduce(allow_empty=False).value
+    if weighted:
+        maxval = G.get_property("max_element-")
+        L = unary.cbrt(L / maxval)
+        r = unary.cbrt(r / maxval)
+        semiring = plus_times
+    else:
+        semiring = plus_pair
+    val = semiring(L @ r).new(mask=r.S)
+    if weighted:
+        val *= r
+    return val.reduce(allow_empty=False).value
 
 
-def triangles_core(G, mask=None):
+def triangles_core(G, *, weighted=False, mask=None):
     # Ignores self-edges
     L, U = G.get_properties("L- U-")
-    C = plus_pair(L @ L.T).new(mask=L.S)
+    if weighted:
+        maxval = G.get_property("max_element-")
+        L = unary.cbrt(L / maxval)
+        U = unary.cbrt(U / maxval)
+        semiring = plus_times
+    else:
+        semiring = plus_pair
+    C = semiring(L @ L.T).new(mask=L.S)
+    D = semiring(U @ L.T).new(mask=U.S)
+    if weighted:
+        C *= L
+        D *= U
     return (
         C.reduce_rowwise().new(mask=mask)
         + C.reduce_columnwise().new(mask=mask)
-        + plus_pair(U @ L.T).new(mask=U.S).reduce_rowwise().new(mask=mask)
+        + D.reduce_rowwise().new(mask=mask)
     ).new(name="triangles")
 
 
@@ -59,10 +78,7 @@ def transitivity_core(G):
 
 def transitivity_directed_core(G):
     # XXX" is transitivity supposed to work on directed graphs like this?
-    if G.get_property("has_self_edges"):
-        A = G.get_property("offdiag")
-    else:
-        A = G._A
+    A, AT = G.get_properties("offdiag AT")
     numerator = plus_pair(A @ A.T).new(mask=A.S).reduce_scalar(allow_empty=False).value
     if numerator == 0:
         return 0
@@ -82,32 +98,41 @@ def transitivity(G):
     return G._cacheit("transitivity", func, G)
 
 
-def clustering_core(G, mask=None):
-    tri = triangles_core(G, mask=mask)
+def clustering_core(G, *, weighted=False, mask=None):
+    tri = triangles_core(G, weighted=weighted, mask=mask)
     degrees = G.get_property("degrees-")
     denom = degrees * (degrees - 1)
     return (2 * tri / denom).new(name="clustering")
 
 
-def clustering_directed_core(G, mask=None):
-    if G.get_property("has_self_edges"):
-        A = G.get_property("offdiag")
+def clustering_directed_core(G, *, weighted=False, mask=None):
+    A, AT = G.get_properties("offdiag AT")
+    if weighted:
+        maxval = G.get_property("max_element-")
+        A = unary.cbrt(A / maxval)
+        AT = unary.cbrt(AT / maxval)
+        semiring = plus_times
     else:
-        A = G._A
-    AT = G.get_property("AT")
-    temp = plus_pair(A @ A.T).new(mask=A.S)
+        semiring = plus_pair
+    C = semiring(A @ A.T).new(mask=A.S)
+    D = semiring(AT @ A.T).new(mask=A.S)
+    E = semiring(AT @ AT.T).new(mask=A.S)
+    if weighted:
+        C *= A
+        D *= A
+        E *= A
     tri = (
-        temp.reduce_rowwise().new(mask=mask)
-        + temp.reduce_columnwise().new(mask=mask)
-        + plus_pair(AT @ A.T).new(mask=A.S).reduce_rowwise().new(mask=mask)
-        + plus_pair(AT @ AT.T).new(mask=A.S).reduce_columnwise().new(mask=mask)
+        C.reduce_rowwise().new(mask=mask)
+        + C.reduce_columnwise().new(mask=mask)
+        + D.reduce_rowwise().new(mask=mask)
+        + E.reduce_columnwise().new(mask=mask)
     )
     recip_degrees, total_degrees = G.get_properties("recip_degrees- total_degrees-", mask=mask)
     return (tri / (total_degrees * (total_degrees - 1) - 2 * recip_degrees)).new(name="clustering")
 
 
-def single_clustering_core(G, node):
-    tri = single_triangle_core(G, node)
+def single_clustering_core(G, node, *, weighted=False):
+    tri = single_triangle_core(G, node, weighted=weighted)
     if tri == 0:
         return 0
     index = G._key_to_id[node]
@@ -118,7 +143,7 @@ def single_clustering_core(G, node):
         if G.get_property("has_self_edges") and G._A[index, index].value is not None:
             degrees -= 1
     else:
-        row = G._A[index, :].new()
+        row = G._A[index, :]
         degrees = row.nvals
         if G.get_property("has_self_edges") and row[index].value is not None:
             degrees -= 1
@@ -126,19 +151,31 @@ def single_clustering_core(G, node):
     return 2 * tri / denom
 
 
-def single_clustering_directed_core(G, node, *, has_self_edges=True):
-    if G.get_property("has_self_edges"):
-        A = G.get_property("offdiag")
-    else:
-        A = G._A
+def single_clustering_directed_core(G, node, *, weighted=False):
+    A = G.get_property("offdiag")
     index = G._key_to_id[node]
-    r = A[index, :].new()
-    c = A[:, index].new()
+    if weighted:
+        maxval = G.get_property("max_element-")
+        A = unary.cbrt(A / maxval)
+        semiring = plus_times
+    else:
+        semiring = plus_pair
+    r = A[index, :]
+    c = A[:, index]
+    v1 = semiring(A @ c).new(mask=c.S)
+    v2 = semiring(A @ c).new(mask=r.S)
+    v3 = semiring(A @ r).new(mask=c.S)
+    v4 = semiring(A @ r).new(mask=r.S)
+    if weighted:
+        v1 *= c
+        v2 *= r
+        v3 *= c
+        v4 *= r
     tri = (
-        plus_pair(A @ c).new(mask=c.S).reduce(allow_empty=False).value
-        + plus_pair(A @ c).new(mask=r.S).reduce(allow_empty=False).value
-        + plus_pair(A @ r).new(mask=c.S).reduce(allow_empty=False).value
-        + plus_pair(A @ r).new(mask=r.S).reduce(allow_empty=False).value
+        v1.reduce(allow_empty=False).value
+        + v2.reduce(allow_empty=False).value
+        + v3.reduce(allow_empty=False).value
+        + v4.reduce(allow_empty=False).value
     )
     if tri == 0:
         return 0
@@ -148,27 +185,25 @@ def single_clustering_directed_core(G, node, *, has_self_edges=True):
 
 
 def clustering(G, nodes=None, weight=None):
-    if weight is not None:
-        # TODO: Not yet implemented.  Clustering implemented only for unweighted.
-        return _nx_clustering(G, nodes=nodes, weight=weight)
     G = to_graph(G, weight=weight)  # to directed or undirected
     if len(G) == 0:
         return {}
+    weighted = weight is not None
     if nodes in G:
         if G.is_directed():
-            return single_clustering_directed_core(G, nodes)
+            return single_clustering_directed_core(G, nodes, weighted=weighted)
         else:
-            return single_clustering_core(G, nodes)
+            return single_clustering_core(G, nodes, weighted=weighted)
     mask = G.list_to_mask(nodes)
     if G.is_directed():
-        result = clustering_directed_core(G, mask=mask)
+        result = clustering_directed_core(G, weighted=weighted, mask=mask)
     else:
-        result = clustering_core(G, mask=mask)
+        result = clustering_core(G, weighted=weighted, mask=mask)
     return G.vector_to_dict(result, mask=mask, fillvalue=0.0)
 
 
-def average_clustering_core(G, mask=None, count_zeros=True):
-    c = clustering_core(G, mask=mask)
+def average_clustering_core(G, *, count_zeros=True, weighted=False, mask=None):
+    c = clustering_core(G, weighted=weighted, mask=mask)
     val = c.reduce(allow_empty=False).value
     if not count_zeros:
         return val / c.nvals
@@ -178,8 +213,8 @@ def average_clustering_core(G, mask=None, count_zeros=True):
         return val / c.size
 
 
-def average_clustering_directed_core(G, mask=None, count_zeros=True):
-    c = clustering_directed_core(G, mask=mask)
+def average_clustering_directed_core(G, *, count_zeros=True, weighted=False, mask=None):
+    c = clustering_directed_core(G, weighted=weighted, mask=mask)
     val = c.reduce(allow_empty=False).value
     if not count_zeros:
         return val / c.nvals
@@ -190,12 +225,10 @@ def average_clustering_directed_core(G, mask=None, count_zeros=True):
 
 
 def average_clustering(G, nodes=None, weight=None, count_zeros=True):
-    if weight is not None:
-        # TODO: Not yet implemented.  Clustering implemented only for unweighted.
-        return _nx_average_clustering(G, nodes=nodes, weight=weight, count_zeros=count_zeros)
     G = to_graph(G, weight=weight)  # to directed or undirected
     if len(G) == 0:
         raise ZeroDivisionError()  # Not covered
+    weighted = weight is not None
     mask = G.list_to_mask(nodes)
     if G.is_directed():
         func = average_clustering_directed_core
@@ -203,7 +236,11 @@ def average_clustering(G, nodes=None, weight=None, count_zeros=True):
         func = average_clustering_core
     if mask is None:
         return G._cacheit(
-            f"average_clustering(count_zeros={count_zeros})", func, G, count_zeros=count_zeros
+            f"average_clustering(count_zeros={count_zeros})",
+            func,
+            G,
+            weighted=weighted,
+            count_zeros=count_zeros,
         )
     else:
-        return func(G, mask=mask, count_zeros=count_zeros)
+        return func(G, weighted=weighted, count_zeros=count_zeros, mask=mask)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-graphblas >=2022.4.2
+python-graphblas >=2022.5.0
 networkx


### PR DESCRIPTION
I actually think this is pretty neat.

In order for this to pass tests, we'll need to:
- release `python-graphblas`, since this depends on `unary.cbrt`
- update some NetworkX tests to use `np.testing.assert_allclose` when comparing floating point numbers
  - while we're at it, it may be nice to add more tests to increase our coverage
 
With this, `clustering.py` is one step closer to being complete.  It still needs:
- `square_clustering`, no idea how to do this (but I haven't looked into it either)
- `generalized_degree`, which looks very doable