### PR TITLE
Improve square clustering

### DIFF
--- a/graphblas_algorithms/conftest.py
+++ b/graphblas_algorithms/conftest.py
@@ -31,7 +31,12 @@ def orig():
     for key, (orig_val, new_val) in replacements.items():
         setattr(orig, key, orig_val)
         if key not in {"pagerank_numpy"}:
-            assert inspect.signature(orig_val) == inspect.signature(new_val), key
+            # Ignore keyword-only parameters (works until NetworkX has keyword-only arguments)
+            sig = inspect.signature(new_val)
+            sig = sig.replace(
+                parameters=[x for x in sig.parameters.values() if x.kind != x.KEYWORD_ONLY]
+            )
+            assert inspect.signature(orig_val) == sig, key
     for name, module in sys.modules.items():
         if not name.startswith("networkx.") and name != "networkx":
             continue

--- a/graphblas_algorithms/conftest.py
+++ b/graphblas_algorithms/conftest.py
@@ -26,11 +26,9 @@ def orig():
         and not isinstance(val, types.ModuleType)
         and key not in {"Graph", "DiGraph"}
     }
-    replacements["pagerank_scipy"] = (nx.pagerank_scipy, ga.pagerank)
-    replacements["pagerank_numpy"] = (nx.pagerank_numpy, ga.pagerank)
     for key, (orig_val, new_val) in replacements.items():
         setattr(orig, key, orig_val)
-        if key not in {"pagerank_numpy"}:
+        if key not in {}:
             # Ignore keyword-only parameters (works until NetworkX has keyword-only arguments)
             sig = inspect.signature(new_val)
             sig = sig.replace(


### PR DESCRIPTION
Completely remove the old way of computing square clustering coefficients.  It served its purpose.

I figured out a better way to compute `uw_degrees` contribution to the denominator:
```python
uw_degrees = plus_times(A @ degrees) * (degrees - 1)
```
Obvious, right?  I'm kidding.  But, this does seem to compute `degrees[u] + degrees[w]` for all u-w pairs for a given node, and it's a *whole* lot faster than what we were doing before.

- Updated to use `binary.cdiv`, because UDF for `floor_div` is really slow.
- Updated to work on a subset of node_ids.
- Added function to compute square coefficient for a single node.
  - This was actually helpful in determining the new expression for `uw_degrees`
- Added `nsplits=None` keyword argument to `square_clustering`:
  - Very large graphs may run out of memory, so use `nsplits` to compute in a chunked manner (which is slower).
  - Do we like this name?  Is it more natural to specify the number of splits or the size of the chunks, or allow both?
  - Does networkx ever plan to add keyword-only arguments?  This impacts comparing signatures.

For a more detailed summary of this algorithm, see the companion PR in LAGraph: https://github.com/GraphBLAS/LAGraph/pull/133