### PR TITLE
Basic graph generation using hypothesis, compare outputs with NX

### DIFF
--- a/graphblas_algorithms/algorithms/link_analysis/tests/test_pagerank.py
+++ b/graphblas_algorithms/algorithms/link_analysis/tests/test_pagerank.py
@@ -1,3 +1,14 @@
+import pytest
+from hypothesis import given, settings
+
 from graphblas_algorithms import pagerank
+from graphblas_algorithms.utils import custom_graph_generators
+
+
+@settings(deadline=None, max_examples=500)
+@given(custom_graph_generators())
+def test_pagerank_gen(graph):
+    assert pagerank(graph) == pytest.approx(nx.pagerank(graph))
+
 
 from networkx.algorithms.link_analysis.tests.test_pagerank import *  # isort:skip

--- a/graphblas_algorithms/algorithms/tests/test_reciprocity.py
+++ b/graphblas_algorithms/algorithms/tests/test_reciprocity.py
@@ -1,3 +1,22 @@
 from graphblas_algorithms import overall_reciprocity, reciprocity
+import pytest
+from hypothesis import given, settings
+from graphblas_algorithms.utils import custom_graph_generators
+
+
+@settings(deadline=None, max_examples=500)
+@given(custom_graph_generators())
+def test_overall_reciprocity_gen(graph):
+    # TODO: Fix the graph gen to not produce empty graphs and control directions
+    if len(graph) > 0 and graph.is_directed():
+        assert overall_reciprocity(graph) == pytest.approx(nx.overall_reciprocity(graph))
+
+
+@settings(deadline=None, max_examples=500)
+@given(custom_graph_generators())
+def test_reciprocity_gen(graph):
+    if len(graph) > 0 and graph.is_directed():
+        assert reciprocity(graph) == pytest.approx(nx.reciprocity(graph))
+
 
 from networkx.algorithms.tests.test_reciprocity import *  # isort:skip

--- a/graphblas_algorithms/utils/__init__.py
+++ b/graphblas_algorithms/utils/__init__.py
@@ -1,2 +1,3 @@
 from ._misc import *
 from .decorators import *
+from .graph_gen import *

--- a/graphblas_algorithms/utils/graph_gen.py
+++ b/graphblas_algorithms/utils/graph_gen.py
@@ -1,0 +1,30 @@
+import networkx as nx
+from hypothesis.strategies import booleans, composite, integers, lists, tuples
+
+
+@composite
+def custom_graph_generators(
+    draw,
+    directed=booleans(),
+    self_loops=booleans(),
+    sym_digraph=booleans(),
+    edges=tuples(integers(0, 100), integers(0, 100), integers(-100, 100)),
+    edge_data=booleans(),
+):
+    G = nx.DiGraph() if draw(directed) else nx.Graph()
+    self_loop = draw(self_loops)
+    edges = draw(lists(edges, max_size=1000))
+    edge_data = draw(edge_data)
+    for u, v, d in edges:
+        if not self_loop and u == v:
+            continue
+        if edge_data:
+            G.add_edge(u, v, data=d)
+        else:
+            G.add_edge(u, v)
+    if G.is_directed():
+        sym_digraph = draw(sym_digraph)
+        if sym_digraph:
+            G = G.to_undirected()
+            G = G.to_directed()
+    return G


### PR DESCRIPTION
To extend tests https://github.com/python-graphblas/graphblas-algorithms/issues/10
Using `hypothesis` to generate a combinations of graphs to compare the outputs of nx implementation and graphblas ones. I'm not a 100% sure if this is the best way of doing this (this is the first time I'm writing hypothesis tests) and the coverage would be pretty poor as there are a lot of assumptions. Currently the graph generator gives a sample of graphs with the toggles:

- directed: bool generate a directed graph
- self_loops: bool to control if self edges are allowed 
- sym_digraph: bool to control the symmetric digraphs.
- edges: generates a 3-tuple of edge data, all our integers
- edge_data: bool to control if the edge should be weighted or not.