### PR TITLE
This recipe for smetric is the fastest

### DIFF
--- a/graphblas_algorithms/algorithms/smetric.py
+++ b/graphblas_algorithms/algorithms/smetric.py
@@ -1,3 +1,5 @@
+from graphblas import binary
+
 __all__ = ["s_metric"]
 
 
@@ -6,7 +8,7 @@ def s_metric(G):
         degrees = G.get_property("total_degrees+")
     else:
         degrees = G.get_property("degrees+")
+    return (binary.first(degrees & G._A) @ degrees).reduce().get(0) / 2
     # Alternatives
     # return (degrees @ binary.second(G._A & degrees)).reduce().get(0) / 2
-    # return (binary.first(degrees & G._A) @ degrees).reduce().get(0) / 2
-    return degrees.outer(degrees).new(mask=G._A.S).reduce_scalar().get(0) / 2
+    # return degrees.outer(degrees).new(mask=G._A.S).reduce_scalar().get(0) / 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,9 @@ exclude =
     graphblas_algorithms/*/tests/,
     graphblas_algorithms/*/*/tests/,
     build/
-ignore =
-    E203,   # whitespace before ':'
-    E231,   # Multiple spaces around ","
-    W503,   # line break before binary operator
+extend-ignore =
+    E203,
+# E203 whitespace before ':' (to be compatible with black)
 per-file-ignores =
     __init__.py:F401,F403,  # allow unused and star imports
     test_*.py:F401,F403,


### PR DESCRIPTION
There's a big difference in performance of the three implementations in the code. Benchmarking made clear which is the fastest. Lesson reinforced: try not use use `outer` followed by reduction.

Also, we can probably remove the extra `with_authority=False` option in HITS (using the authority matrix is slower and uses more memory), but I'll run a few more benchmarks on this to make sure.