### PR TITLE
Add floyd_warshall_predecessor_and_distance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.11
+    rev: v0.12.1
     hooks:
       - id: validate-pyproject
         name: Validate pyproject.toml
   - repo: https://github.com/myint/autoflake
-    rev: v2.0.0
+    rev: v2.0.1
     hooks:
       - id: autoflake
         args: [--in-place]
@@ -44,7 +44,7 @@ repos:
       - id: auto-walrus
         args: [--line-length, "100"]
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         args: [--target-version=py38]

--- a/graphblas_algorithms/classes/digraph.py
+++ b/graphblas_algorithms/classes/digraph.py
@@ -569,6 +569,8 @@ class DiGraph(Graph):
     list_to_mask = _utils.list_to_mask
     list_to_ids = _utils.list_to_ids
     matrix_to_dicts = _utils.matrix_to_dicts
+    matrix_to_nodenodemap = _utils.matrix_to_nodenodemap
+    matrix_to_vectornodemap = _utils.matrix_to_vectornodemap
     set_to_vector = _utils.set_to_vector
     to_networkx = _utils.to_networkx
     vector_to_dict = _utils.vector_to_dict

--- a/graphblas_algorithms/classes/graph.py
+++ b/graphblas_algorithms/classes/graph.py
@@ -275,6 +275,8 @@ class Graph:
     list_to_ids = _utils.list_to_ids
     list_to_keys = _utils.list_to_keys
     matrix_to_dicts = _utils.matrix_to_dicts
+    matrix_to_nodenodemap = _utils.matrix_to_nodenodemap
+    matrix_to_vectornodemap = _utils.matrix_to_vectornodemap
     set_to_vector = _utils.set_to_vector
     to_networkx = _utils.to_networkx
     vector_to_dict = _utils.vector_to_dict

--- a/graphblas_algorithms/classes/nodemap.py
+++ b/graphblas_algorithms/classes/nodemap.py
@@ -6,13 +6,15 @@ from . import _utils
 
 
 class NodeMap(MutableMapping):
-    def __init__(self, v, *, key_to_id=None):
+    def __init__(self, v, *, fill_value=None, values_are_keys=False, key_to_id=None):
         self.vector = v
         if key_to_id is None:
             self._key_to_id = {i: i for i in range(v.size)}
         else:
             self._key_to_id = key_to_id
         self._id_to_key = None
+        self._fill_value = fill_value
+        self._values_are_keys = values_are_keys
 
     id_to_key = property(_utils.id_to_key)
     # get_property = _utils.get_property
@@ -39,38 +41,60 @@ class NodeMap(MutableMapping):
     def __getitem__(self, key):
         idx = self._key_to_id[key]
         if (rv := self.vector.get(idx)) is not None:
+            if self._values_are_keys:
+                return self.id_to_key[rv]
             return rv
+        if self._fill_value is not None:
+            return self._fill_value
         raise KeyError(key)
 
     def __iter__(self):
+        if self._fill_value is not None:
+            return iter(self._key_to_id)
         # Slow if we iterate over one; fast if we iterate over all
         return map(
             self.id_to_key.__getitem__, self.vector.to_coo(values=False, sort=False)[0].tolist()
         )
 
     def __len__(self):
+        if self._fill_value is not None:
+            return len(self._key_to_id)
         return self.vector.nvals
 
     def __setitem__(self, key, val):
         idx = self._key_to_id[key]
+        if self._values_are_keys:
+            val = self._key_to_id[val]
         self.vector[idx] = val
 
     # Override other MutableMapping methods
     def __contains__(self, key):
         idx = self._key_to_id[key]
-        return idx in self.vector
+        return self._fill_value is not None or idx in self.vector
 
     def __eq__(self, other):
         if isinstance(other, NodeMap):
-            return self.vector.isequal(other.vector) and self._key_to_id == other._key_to_id
+            return (
+                self._values_are_keys == other._values_are_keys
+                and self._fill_value == other._fill_value
+                and self.vector.isequal(other.vector)
+                and self._key_to_id == other._key_to_id
+            )
         return super().__eq__(other)
 
     def clear(self):
         self.vector.clear()
+        self._fill_value = None
 
     def get(self, key, default=None):
         idx = self._key_to_id[key]
-        return self.vector.get(idx, default)
+        rv = self.vector.get(idx)
+        if rv is None:
+            if self._fill_value is not None:
+                return self._fill_value
+            return default
+        if self._values_are_keys:
+            return self.id_to_key[rv]
 
     # items
     # keys
@@ -83,13 +107,20 @@ class NodeMap(MutableMapping):
         except StopIteration:
             raise KeyError from None
         del v[idx]
+        if self._values_are_keys:
+            value = self.id_to_key[value]
         return self.id_to_key[idx], value
 
     def setdefault(self, key, default=None):
         idx = self._key_to_id[key]
         if (value := self.vector.get(idx)) is not None:
+            if self._values_are_keys:
+                return self.id_to_key[value]
             return value
-        self.vector[idx] = default
+        if self._fill_value is not None:
+            return self._fill_value
+        if default is not None:
+            self.vector[idx] = default
         return default
 
     # update
@@ -265,6 +296,144 @@ class VectorNodeMap(MutableMapping):
         except StopIteration:
             raise KeyError from None
         value = VectorMap(self.matrix[idx, :].new())
+        del self.matrix[idx, :]
+        del rows[idx]
+        return self.id_to_key[idx], value
+
+    # setdefault
+    # update
+    # values
+
+
+class NodeNodeMap(MutableMapping):
+    def __init__(self, A, *, fill_value=None, values_are_keys=False, key_to_id=None):
+        self.matrix = A
+        if key_to_id is None:
+            self._key_to_id = {i: i for i in range(A.size)}
+        else:
+            self._key_to_id = key_to_id
+        self._id_to_key = None
+        self._rows = None
+        self._fill_value = fill_value
+        self._values_are_keys = values_are_keys
+
+    def _get_rows(self):
+        if self._rows is None:
+            self._rows = self.matrix.reduce_rowwise(monoid.any).new()
+            self._rows(self._rows.S) << 1  # Make iso-valued
+        return self._rows
+
+    id_to_key = property(_utils.id_to_key)
+    # get_property = _utils.get_property
+    # get_properties = _utils.get_properties
+    dict_to_vector = _utils.dict_to_vector
+    list_to_vector = _utils.list_to_vector
+    list_to_mask = _utils.list_to_mask
+    list_to_ids = _utils.list_to_ids
+    list_to_keys = _utils.list_to_keys
+    matrix_to_dicts = _utils.matrix_to_dicts
+    set_to_vector = _utils.set_to_vector
+    # to_networkx = _utils.to_networkx
+    vector_to_dict = _utils.vector_to_dict
+    vector_to_nodemap = _utils.vector_to_nodemap
+    vector_to_nodeset = _utils.vector_to_nodeset
+    vector_to_set = _utils.vector_to_set
+    # _cacheit = _utils._cacheit
+
+    # Requirements for MutableMapping
+    def __delitem__(self, key):
+        idx = self._key_to_id[key]
+        del self.matrix[idx, :]
+        if self._rows is not None:
+            del self._rows[idx]
+
+    def __getitem__(self, key):
+        idx = self._key_to_id[key]
+        if self._fill_value is None and self._get_rows().get(idx) is None:
+            raise KeyError(key)
+        return self.vector_to_nodemap(
+            self.matrix[idx, :].new(),
+            fill_value=self._fill_value,
+            values_are_keys=self._values_are_keys,
+        )
+
+    def __iter__(self):
+        if self._fill_value is not None:
+            return iter(self._key_to_id)
+        # Slow if we iterate over one; fast if we iterate over all
+        return map(
+            self.id_to_key.__getitem__,
+            self._get_rows().to_coo(values=False, sort=False)[0].tolist(),
+        )
+
+    def __len__(self):
+        if self._fill_value is not None:
+            return len(self._key_to_id)
+        return self._get_rows().nvals
+
+    def __setitem__(self, key, val):
+        idx = self._key_to_id[key]
+        if isinstance(val, NodeMap):
+            # TODO: check val._key_to_id?
+            val = val.vector
+        elif isinstance(val, dict):
+            val = Vector.from_dict(val, self.matrix.dtype, size=self.matrix.ncols)
+        else:
+            raise TypeError()
+        if val.nvals == 0:
+            del self.matrix[idx, :]
+            if self._rows is not None:
+                del self._rows[idx]
+        else:
+            self.matrix[idx, :] = val
+            if self._rows is not None:
+                self._rows[idx] = 1
+
+    # Override other MutableMapping methods
+    def __contains__(self, key):
+        idx = self._key_to_id[key]
+        return self._fill_value is not None or idx in self._get_rows()
+
+    def __eq__(self, other):
+        if isinstance(other, NodeNodeMap):
+            return (
+                self._fill_value == other._fill_value
+                and self._values_are_keys == other._values_are_keys
+                and self.matrix.isequal(other.matrix)
+                and self._key_to_id == other._key_to_id
+            )
+        return super().__eq__(other)
+
+    def clear(self):
+        self.matrix.clear()
+        self._rows = None
+        self._fill_value = None
+
+    def get(self, key, default=None):
+        idx = self._key_to_id[key]
+        if self._fill_value is None and self._get_rows().get(idx) is None:
+            return default
+        self.vector_to_nodemap(
+            self.matrix[idx, :].new(),
+            fill_value=self._fill_value,
+            values_are_keys=self._values_are_keys,
+        )
+
+    # items
+    # keys
+    # pop
+
+    def popitem(self):
+        rows = self._get_rows()
+        try:
+            idx = next(rows.ss.iterkeys())
+        except StopIteration:
+            raise KeyError from None
+        value = self.vector_to_nodemap(
+            self.matrix[idx, :].new(),
+            fill_value=self._fill_value,
+            values_are_keys=self._values_are_keys,
+        )
         del self.matrix[idx, :]
         del rows[idx]
         return self.id_to_key[idx], value

--- a/graphblas_algorithms/interface.py
+++ b/graphblas_algorithms/interface.py
@@ -56,6 +56,9 @@ class Dispatcher:
     is_regular = nxapi.regular.is_regular
     # Shortest Paths
     floyd_warshall = nxapi.shortest_paths.dense.floyd_warshall
+    floyd_warshall_predecessor_and_distance = (
+        nxapi.shortest_paths.dense.floyd_warshall_predecessor_and_distance
+    )
     has_path = nxapi.shortest_paths.generic.has_path
     # Simple Paths
     is_simple_path = nxapi.simple_paths.is_simple_path

--- a/graphblas_algorithms/nxapi/centrality/degree_alg.py
+++ b/graphblas_algorithms/nxapi/centrality/degree_alg.py
@@ -8,18 +8,18 @@ __all__ = ["degree_centrality", "in_degree_centrality", "out_degree_centrality"]
 def degree_centrality(G):
     G = to_graph(G)
     result = algorithms.degree_centrality(G)
-    return G.vector_to_nodemap(result, fillvalue=0.0)
+    return G.vector_to_nodemap(result, fill_value=0.0)
 
 
 @not_implemented_for("undirected")
 def in_degree_centrality(G):
     G = to_directed_graph(G)
     result = algorithms.in_degree_centrality(G)
-    return G.vector_to_nodemap(result, fillvalue=0.0)
+    return G.vector_to_nodemap(result, fill_value=0.0)
 
 
 @not_implemented_for("undirected")
 def out_degree_centrality(G):
     G = to_directed_graph(G)
     result = algorithms.out_degree_centrality(G)
-    return G.vector_to_nodemap(result, fillvalue=0.0)
+    return G.vector_to_nodemap(result, fill_value=0.0)

--- a/graphblas_algorithms/nxapi/cluster.py
+++ b/graphblas_algorithms/nxapi/cluster.py
@@ -3,7 +3,6 @@ from graphblas import monoid
 from graphblas_algorithms import algorithms
 from graphblas_algorithms.classes.digraph import to_graph
 from graphblas_algorithms.classes.graph import to_undirected_graph
-from graphblas_algorithms.classes.nodemap import VectorNodeMap
 from graphblas_algorithms.utils import not_implemented_for
 
 __all__ = [
@@ -25,7 +24,7 @@ def triangles(G, nodes=None):
         return algorithms.single_triangle(G, nodes)
     mask = G.list_to_mask(nodes)
     result = algorithms.triangles(G, mask=mask)
-    return G.vector_to_nodemap(result, mask=mask, fillvalue=0)
+    return G.vector_to_nodemap(result, mask=mask, fill_value=0)
 
 
 def transitivity(G):
@@ -54,7 +53,7 @@ def clustering(G, nodes=None, weight=None):
         result = algorithms.clustering_directed(G, weighted=weighted, mask=mask)
     else:
         result = algorithms.clustering(G, weighted=weighted, mask=mask)
-    return G.vector_to_nodemap(result, mask=mask, fillvalue=0.0)
+    return G.vector_to_nodemap(result, mask=mask, fill_value=0.0)
 
 
 def average_clustering(G, nodes=None, weight=None, count_zeros=True):
@@ -116,7 +115,7 @@ def square_clustering(G, nodes=None, *, nsplits=None):
             result = algorithms.square_clustering(G)
         else:
             result = _square_clustering_split(G, nsplits=nsplits)
-        return G.vector_to_nodemap(result, fillvalue=0)
+        return G.vector_to_nodemap(result, fill_value=0)
     elif nodes in G:
         idx = G._key_to_id[nodes]
         return algorithms.single_square_clustering(G, idx)
@@ -139,6 +138,4 @@ def generalized_degree(G, nodes=None):
         return G.vector_to_nodemap(result)
     mask = G.list_to_mask(nodes)
     result = algorithms.generalized_degree(G, mask=mask)
-    rv = VectorNodeMap(result, key_to_id=G._key_to_id)
-    rv._id_to_key = G._id_to_key
-    return rv
+    return G.matrix_to_vectornodemap(result)

--- a/graphblas_algorithms/nxapi/link_analysis/hits_alg.py
+++ b/graphblas_algorithms/nxapi/link_analysis/hits_alg.py
@@ -20,4 +20,4 @@ def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
             raise ArpackNoConvergence(*e.args, (), ()) from e
         # TODO: it would be nice if networkx raised their own exception, such as:
         # raise nx.PowerIterationFailedConvergence(*e.args) from e
-    return G.vector_to_nodemap(h, fillvalue=0), G.vector_to_nodemap(a, fillvalue=0)
+    return G.vector_to_nodemap(h, fill_value=0), G.vector_to_nodemap(a, fill_value=0)

--- a/graphblas_algorithms/nxapi/link_analysis/pagerank_alg.py
+++ b/graphblas_algorithms/nxapi/link_analysis/pagerank_alg.py
@@ -39,6 +39,6 @@ def pagerank(
             dangling=dangling_weights,
             row_degrees=row_degrees,
         )
-        return G.vector_to_nodemap(result, fillvalue=0.0)
+        return G.vector_to_nodemap(result, fill_value=0.0)
     except algorithms.exceptions.ConvergenceFailure as e:
         raise PowerIterationFailedConvergence(*e.args) from e

--- a/graphblas_algorithms/nxapi/shortest_paths/dense.py
+++ b/graphblas_algorithms/nxapi/shortest_paths/dense.py
@@ -1,10 +1,19 @@
 from graphblas_algorithms import algorithms
 from graphblas_algorithms.classes.digraph import to_graph
 
-__all__ = ["floyd_warshall"]
+__all__ = ["floyd_warshall", "floyd_warshall_predecessor_and_distance"]
 
 
 def floyd_warshall(G, weight="weight"):
     G = to_graph(G, weight=weight)
     D = algorithms.floyd_warshall(G, is_weighted=weight is not None)
-    return G.matrix_to_dicts(D)
+    return G.matrix_to_nodenodemap(D)
+
+
+def floyd_warshall_predecessor_and_distance(G, weight="weight"):
+    G = to_graph(G, weight=weight)
+    P, D = algorithms.floyd_warshall_predecessor_and_distance(G, is_weighted=weight is not None)
+    return (
+        G.matrix_to_nodenodemap(P, values_are_keys=True),
+        G.matrix_to_nodenodemap(D, fill_value=float("inf")),
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-graphblas >=2022.11.0
+python-graphblas >=2023.1.0

--- a/scripts/scipy_impl.py
+++ b/scripts/scipy_impl.py
@@ -14,7 +14,6 @@ def pagerank(
     weight="weight",
     dangling=None,
 ):
-
     N = A.shape[0]
     if A.nnz == 0:
         return {}


### PR DESCRIPTION
This follows up on #42 to also compute predecessors with floyd_warshall.

CC @jim22k @SultanOrazbayev @LuisFelipeRamos

I came up with the algorithm for computing predecessors via trial and error--i.e., a lot of guessing :). The outcome seems reasonable/plausible, and it passes tests.

As the comments indicate, by adding the use of `Mask`, we increase memory usage, but it computes faster. I don't have a great feel for when we should trade memory for speed or vice versa. So, let's go with the simple option, which happens to be the faster option.

Also, instead of converting the output Matrix to a dict of dicts, I convert it to a new object `NodeNodeMap` that behaves similarly and is backed by the matrix. I updated other uses of `fill_value` with `NodeMap` to keep the output sparse (i.e., don't fill with `fill_value`).

I wonder how we can/should optimize for undirected graphs (i.e., symmetric adjacency matrix). Perhaps we can only compute the lower or upper triangular portion of the results while iterating.

Our original `floyd_warshall` was nice, because it looked a lot more like a typical floyd-warshall implementation. The new version that can also compute predecessors is nice b/c it's more capable without duplicating a bunch of code, but less nice b/c it's more complicated. Please let me know if anything in `floyd_warshall_predecessor_and_distance` can be more clear.