### PR TITLE
Add a few igraph algorithms to run via `scripts/bench.py`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,6 +33,9 @@ dependencies:
     - numba
     - python-suitesparse-graphblas
     - pyyaml
+    # python-graphblas extra dependencies
+    - fast_matrix_market
+    - packaging
     # networkx default dependencies
     - matplotlib
     - pandas
@@ -54,3 +57,9 @@ dependencies:
     - ipython
     # For type annotations
     - mypy
+    # For benchmark comparisons (optional; uncomment as desired)
+    # - igraph
+    # - python-igraph
+    # - networkit
+    # - graph-tool
+    # - xorg-libxcursor  # for graph-tool

--- a/graphblas_algorithms/nxapi/_utils.py
+++ b/graphblas_algorithms/nxapi/_utils.py
@@ -100,7 +100,7 @@ def partition(chunksize, L, *, evenly=True):
         yield from L
         return
     if evenly:
-        k = ceil(L / chunksize)
+        k = ceil(len(L) / chunksize)
         if k * chunksize != N:
             yield from split_evenly(k, L)
             return

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -14,6 +14,7 @@ import numpy as np
 import scipy.sparse
 
 import graphblas_algorithms as ga
+import igraph_impl
 import scipy_impl
 from graphblas_algorithms.interface import Dispatcher
 
@@ -56,13 +57,20 @@ def readfile(filepath, is_symmetric, backend):
             return ga.Graph(A)
         return ga.DiGraph(A)
     a = scipy.io.mmread(filepath)
-    if backend == "networkx":
+    if backend in {"networkx", "igraph"}:
         create_using = nx.Graph if is_symmetric else nx.DiGraph
-        return nx.from_scipy_sparse_array(a, create_using=create_using)
+        G = nx.from_scipy_sparse_array(a, create_using=create_using)
+        if backend == "networkx":
+            return G
+        if backend == "igraph":
+            # TODO: is there a better way for igraph to read MM files or scipy.sparse arrays?
+            import igraph
+
+            return igraph.Graph.from_networkx(G)
     if backend == "scipy":
         return scipy.sparse.csr_array(a)
     raise ValueError(
-        f"Backend {backend!r} not understood; must be 'graphblas', 'networkx', or 'scipy'"
+        f"Backend {backend!r} not understood; must be 'graphblas', 'networkx', 'igraph', or 'scipy'"
     )
 
 
@@ -126,6 +134,8 @@ def getfunction(functionname, backend):
         return getattr(Dispatcher, functionname)
     if backend == "scipy":
         return getattr(scipy_impl, functionname)
+    if backend == "igraph":
+        return getattr(igraph_impl, functionname)
     if functionname in functionpaths:
         func = nx
         for attr in functionpaths[functionname].split("."):
@@ -222,7 +232,7 @@ if __name__ == "__main__":
         description=f"Example usage: python {sys.argv[0]} -b graphblas -f pagerank -d amazon0302"
     )
     parser.add_argument(
-        "-b", "--backend", choices=["graphblas", "networkx", "scipy"], default="graphblas"
+        "-b", "--backend", choices=["graphblas", "networkx", "scipy", "igraph"], default="graphblas"
     )
     parser.add_argument(
         "-t", "--time", type=float, default=3.0, help="Target minimum time to run benchmarks"

--- a/scripts/igraph_impl.py
+++ b/scripts/igraph_impl.py
@@ -1,0 +1,46 @@
+def overall_reciprocity(G):
+    return G.reciprocity()
+
+
+def pagerank(
+    G,
+    alpha=0.85,
+    personalization=None,
+    max_iter=100,
+    tol=1e-06,
+    nstart=None,
+    weight="weight",
+    dangling=None,
+    *,
+    vertices=None,
+    directed=True,
+    arpack_options=None,
+    implementation="prpack",
+):
+    if personalization is not None:
+        raise NotImplementedError
+    if nstart is not None:
+        raise NotImplementedError
+    if dangling is not None:
+        raise NotImplementedError
+    rv = G.pagerank(
+        vertices=vertices,
+        directed=directed,
+        damping=alpha,
+        weights=weight,
+        arpack_options=arpack_options,
+        implementation=implementation,
+    )
+    return rv
+
+
+def transitivity(G):
+    return G.transitivity_undirected()
+
+
+def average_clustering(G, nodes=None, weight=None, count_zeros=True):
+    if nodes is not None:
+        raise NotImplementedError
+    # TODO: check results when `count_zeros=False`
+    mode = "zero" if count_zeros else "nan"
+    return G.transitivity_avglocal_undirected(mode=mode, weights=weight)


### PR DESCRIPTION
See #53 (this PR maybe closes it).

CC @szhorvat. I'm not at all familiar with using igraph, so I'm hoping you can take a look at this. What other algorithms do you think would be easy to compare against? I think we can compare some SSSP and BFS algorithms once #51 is in. Also, how is one supposed to load Matrix Market files into an igraph Graph? Going from `*.mtx` file to scipy.sparse to networkx to igraph seems less than ideal.

I'm not sure the most fair way to compare PageRank. On one hand, comparing PageRank with default arguments is fair because that's how they will typically get used in practice. On the other hand, we can view PageRank and other centrality measures as _ranking_ metrics (i.e., order them by score), so a fair comparison could be to run iterative versions of the algorithm until the same _ranking_ is achieved.